### PR TITLE
Feature: reload using regex for window title

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Usage
 
 browser reload::
 
- :ChromeReload      //reload "Google Chrome"
+ :ChromeReload <regex>      //reload "Google Chrome" with optional regex for window title
  :FirefoxReload     //reload "Firefox"
  :OperaReload       //reload "Opera"
  :AllBrowserReload  //reload all browser

--- a/plugin/browser-reload-linux.vim
+++ b/plugin/browser-reload-linux.vim
@@ -1,8 +1,8 @@
-"=========================================================
+    "=========================================================
 " File:        browser-reload-linux.vim
-" Author:      lordm <lordm2005[at]gmail.com>
-" Last Change: 17-Mar-2012.
-" Version:     1.0
+" Author:      sp4ke <chakib.benz[at]gmail.com>
+" Last Change: 1-Jun-2013.
+" Version:     1.1
 " WebPage:     https://github.com/lordm/vim-browser-reload-linux
 " License:     BSD
 "==========================================================
@@ -12,14 +12,23 @@ if !exists('g:returnAppFlag')
     let g:returnAppFlag = 1
 endif 
 
-function! s:ReloadBrowser(browser)
+function! s:ReloadBrowser(browser, ...)
     let l:currentWindow = substitute(system('xdotool getactivewindow'), "\n", "", "")
 
     let l:activateCommand = " windowactivate "
+
     if ( a:browser == "Chrome" || a:browser == "Chromium-browser" )
         let l:activateCommand = ""
     endif
-    exec "silent ! xdotool search --onlyvisible --class " . a:browser . l:activateCommand . " key --clearmodifiers ctrl+r"
+
+
+    if (a:0 == 1) "If using grep window title method
+        let l:searchArgs = "--name " . "'" . a:1 . ".*" . a:browser . "'"
+    else
+        let l:searchArgs = "--class " . a:browser
+    endif
+
+    exec "silent ! xdotool search --onlyvisible " l:searchArgs . l:activateCommand . " key --clearmodifiers ctrl+r"
 
     if g:returnAppFlag
         exec "silent ! xdotool windowactivate " . l:currentWindow
@@ -28,8 +37,8 @@ function! s:ReloadBrowser(browser)
 endfunction
 
 " Google Chrome
-command! -bar ChromeReload call s:ReloadBrowser("Chrome")
-command! -bar ChromeReloadStart ChromeReloadStop | autocmd BufWritePost <buffer> ChromeReload
+command! -nargs=? ChromeReload call s:ReloadBrowser("Chrome", <f-args>)
+command! -nargs=? -bar ChromeReloadStart ChromeReloadStop | autocmd BufWritePost <buffer> ChromeReload <args>
 command! -bar ChromeReloadStop autocmd! BufWritePost <buffer>
 
 " Chromium


### PR DESCRIPTION
I have several desktops on my system and often have several chrome windows open. The default plugin does not seem to work half the time with this setup. Playing around a bit with xdottool I figured out the --class is not the best suited when you have several windows of the same class. 

So here I propose using --name and add an optional argument to the commands . When the argument is present, the plugin tries to search using --name and injecting the regex given in the argument to the command. 

I added this one for chrome as my issue is with chrome. If I have time I'll test it on other browsers before adding it. 
