### PR TITLE
Set --desktop option to workaround https://github.com/jordansissel/xdotool/issues/67

### DIFF
--- a/plugin/browser-reload-linux.vim
+++ b/plugin/browser-reload-linux.vim
@@ -23,7 +23,7 @@ function! s:ReloadBrowser(browser, ...)
         let l:searchArgs = "--class " . "'" . a:browser . "'"
     endif
 
-    exec "silent ! xdotool search --onlyvisible " l:searchArgs . l:activateCommand . " key --clearmodifiers ctrl+r"
+    exec "silent ! xdotool search --onlyvisible --desktop 0 " l:searchArgs . l:activateCommand . " key --clearmodifiers ctrl+r"
 
     if g:returnAppFlag
         exec "silent ! xdotool windowactivate " . l:currentWindow


### PR DESCRIPTION
The windowactivate fails with this output
```
XGetWindowProperty[_NET_WM_DESKTOP] failed (code=1)
```
I'm not fully sure why but adding `--desktop 0` fixes the problem.